### PR TITLE
Updated Tentacle Resource

### DIFF
--- a/DSCResources/cProjectDeploy/cProjectDeploy.psm1
+++ b/DSCResources/cProjectDeploy/cProjectDeploy.psm1
@@ -93,7 +93,7 @@ function Set-TargetResource{
         [Switch]$Wait = $true
     )
 
-    if ($DeployVersion -and $DeployProject){
+    if ($DeployVersion -ne "latest"){
         Invoke-InitialDeploy -name $Name -apiKey $ApiKey -octopusServerUrl $octopusServerUrl -Environments $Environments -Project $DeployProject -Version $DeployVersion -Wait
     }
 	else{

--- a/DSCResources/cProjectDeploy/cProjectDeploy.psm1
+++ b/DSCResources/cProjectDeploy/cProjectDeploy.psm1
@@ -7,10 +7,19 @@ function Invoke-AndAssert {
         throw "Command returned exit code $LASTEXITCODE"
     }
 }
+function Request-File 
+{
+    param (
+        [string]$url,
+        [string]$saveAs
+    )
+ 
+    Write-Verbose "Downloading $url to $saveAs"
+    $downloader = new-object System.Net.WebClient
+    $downloader.DownloadFile($url, $saveAs)
+}
 function Invoke-InitialDeploy{
     param (
-        [Parameter(Mandatory=$True)]
-        [string]$name,
         [Parameter(Mandatory=$True)]
         [string]$apiKey,
         [Parameter(Mandatory=$True)]
@@ -102,9 +111,9 @@ function Set-TargetResource{
     )
 
     if ($DeployVersion -ne "latest"){
-        Invoke-InitialDeploy -name $Name -apiKey $ApiKey -octopusServerUrl $octopusServerUrl -Environments $Environments -Project $DeployProject -Version $DeployVersion -Wait
+        Invoke-InitialDeploy -apiKey $ApiKey -octopusServerUrl $octopusServerUrl -Environments $Environments -Project $DeployProject -Version $DeployVersion -Wait
     }
 	else{
-        Invoke-InitialDeploy -name $Name -apiKey $ApiKey -octopusServerUrl $octopusServerUrl -Environments $Environments -Project $DeployProject -Wait
+        Invoke-InitialDeploy -apiKey $ApiKey -octopusServerUrl $octopusServerUrl -Environments $Environments -Project $DeployProject -Wait
     }
 }

--- a/DSCResources/cProjectDeploy/cProjectDeploy.psm1
+++ b/DSCResources/cProjectDeploy/cProjectDeploy.psm1
@@ -1,0 +1,97 @@
+function Invoke-InitialDeploy{
+    param (
+        [Parameter(Mandatory=$True)]
+        [string]$name,
+        [Parameter(Mandatory=$True)]
+        [string]$apiKey,
+        [Parameter(Mandatory=$True)]
+        [string]$octopusServerUrl,
+        [Parameter(Mandatory=$True)]
+        [string]$Project,
+        [Parameter(Mandatory=$True)]
+        [string[]]$Environments,
+        [string]$Version = "latest",
+        [Switch]$Wait = $true
+    )
+
+    $octoDL = "http://download.octopusdeploy.com/octopus-tools/2.5.10.39/OctopusTools.2.5.10.39.zip"
+    <#if (Test-Path "$($env:SystemDrive)\Octopus\OctopusTools\$($Project)_initial.txt"){
+        Write-Verbose "Initial Deployment for $Project already done, nothing to do"
+        return
+    }#>
+
+    if ( -not (Test-Path "$($env:SystemDrive)\Octopus\OctopusTools\Octo.exe")){
+        if ( -not (Test-Path "$($env:SystemDrive)\Octopus\OctopusTools.zip")){
+            Write-Verbose "Downloading OctopusTools from $octoDL"
+            Request-File -url $octoDL -saveAs "$($env:SystemDrive)\Octopus\OctopusTools.zip"
+        }
+        Write-Verbose "Unpacking OctopusTools to $($env:SystemDrive)\Octopus\OctopusTools\"
+        Add-Type -assemblyname System.IO.Compression.FileSystem
+        [System.IO.Compression.ZipFile]::ExtractToDirectory("$($env:SystemDrive)\Octopus\OctopusTools.zip","$($env:SystemDrive)\Octopus\OctopusTools\")
+
+    }
+    pushd "$($env:SystemDrive)\Octopus\OctopusTools\"
+    foreach ($environment in $environments){
+        Write-Verbose "Deploying Project $Project to environment $environment"
+        $deployArguments = @("deploy-release", "--project", $Project, "--deployto", $environment, "--releaseNumber", $Version, "--specificmachines", $env:COMPUTERNAME, "--server", $octopusServerUrl, "--apiKey", $apiKey)
+        if ($Wait){
+            $deployArguments += "--waitfordeployment"
+        }
+        Invoke-AndAssert { & .\octo.exe $deployArguments}
+    }
+    "Done" | Out-File "$($env:SystemDrive)\Octopus\OctopusTools\$($Project)_initial.txt"
+}
+function Get-TargetResource{
+    param (
+        [Parameter(Mandatory=$True)]
+        [string]$apiKey,
+        [Parameter(Mandatory=$True)]
+        [string]$octopusServerUrl,
+        [Parameter(Mandatory=$True)]
+        [string]$DeployProject,
+        [Parameter(Mandatory=$True)]
+        [string[]]$Environments,
+        [string]$DeployVersion = "latest",
+        [Switch]$Wait = $true
+    )
+}
+function Test-TargetResource{
+    param (
+        [Parameter(Mandatory=$True)]
+        [string]$apiKey,
+        [Parameter(Mandatory=$True)]
+        [string]$octopusServerUrl,
+        [Parameter(Mandatory=$True)]
+        [string]$DeployProject,
+        [Parameter(Mandatory=$True)]
+        [string[]]$Environments,
+        [string]$DeployVersion = "latest",
+        [Switch]$Wait = $true
+    )
+    if (Test-Path "$($env:SystemDrive)\Octopus\OctopusTools\$($Project)_initial.txt"){
+        Write-Verbose "Initial Deployment for $Project already done, nothing to do"
+        return $True
+    }
+    else{return $false}
+}
+function Set-TargetResource{
+    param (
+        [Parameter(Mandatory=$True)]
+        [string]$apiKey,
+        [Parameter(Mandatory=$True)]
+        [string]$octopusServerUrl,
+        [Parameter(Mandatory=$True)]
+        [string]$DeployProject,
+        [Parameter(Mandatory=$True)]
+        [string[]]$Environments,
+        [string]$DeployVersion = "latest",
+        [Switch]$Wait = $true
+    )
+
+    if ($DeployVersion -and $DeployProject){
+        Invoke-InitialDeploy -name $Name -apiKey $ApiKey -octopusServerUrl $octopusServerUrl -Environments $Environments -Project $project -Version $DeployVersion -Wait
+    }
+	else{
+        Invoke-InitialDeploy -name $Name -apiKey $ApiKey -octopusServerUrl $octopusServerUrl -Environments $Environments -Project $project -Wait
+    }
+}

--- a/DSCResources/cProjectDeploy/cProjectDeploy.psm1
+++ b/DSCResources/cProjectDeploy/cProjectDeploy.psm1
@@ -51,9 +51,14 @@ function Get-TargetResource{
         [string]$DeployProject,
         [Parameter(Mandatory=$True)]
         [string[]]$Environments,
-        [string]$DeployVersion = "latest",
-        [Switch]$Wait = $true
+        [string]$DeployVersion = "latest"
     )
+
+    @{
+        "Environments" = $Environments
+        "Project" = $DeployProject
+        "Project Version" = $DeployVersion
+    }
 }
 function Test-TargetResource{
     param (
@@ -68,8 +73,8 @@ function Test-TargetResource{
         [string]$DeployVersion = "latest",
         [Switch]$Wait = $true
     )
-    if (Test-Path "$($env:SystemDrive)\Octopus\OctopusTools\$($Project)_initial.txt"){
-        Write-Verbose "Initial Deployment for $Project already done, nothing to do"
+    if (Test-Path "$($env:SystemDrive)\Octopus\OctopusTools\$($DeployProject)_initial.txt"){
+        Write-Verbose "Initial Deployment for $DeployProject already done, nothing to do"
         return $True
     }
     else{return $false}
@@ -89,9 +94,9 @@ function Set-TargetResource{
     )
 
     if ($DeployVersion -and $DeployProject){
-        Invoke-InitialDeploy -name $Name -apiKey $ApiKey -octopusServerUrl $octopusServerUrl -Environments $Environments -Project $project -Version $DeployVersion -Wait
+        Invoke-InitialDeploy -name $Name -apiKey $ApiKey -octopusServerUrl $octopusServerUrl -Environments $Environments -Project $DeployProject -Version $DeployVersion -Wait
     }
 	else{
-        Invoke-InitialDeploy -name $Name -apiKey $ApiKey -octopusServerUrl $octopusServerUrl -Environments $Environments -Project $project -Wait
+        Invoke-InitialDeploy -name $Name -apiKey $ApiKey -octopusServerUrl $octopusServerUrl -Environments $Environments -Project $DeployProject -Wait
     }
 }

--- a/DSCResources/cProjectDeploy/cProjectDeploy.schema.mof
+++ b/DSCResources/cProjectDeploy/cProjectDeploy.schema.mof
@@ -1,19 +1,12 @@
-[ClassVersion("1.0.0"), FriendlyName("cTentacleAgent")] 
-class cTentacleAgent : OMI_BaseResource
+[ClassVersion("1.0.0"), FriendlyName("cProjectDeploy")] 
+class cProjectDeploy : OMI_BaseResource
 {
-  [Key] string Name;
-  [Write,ValueMap{"Present", "Absent"},Values{"Present", "Absent"}] string Ensure;
-  [Write,ValueMap{"Started","Stopped"},Values{"Started", "Stopped"}] string State;
-
   [Write] string ApiKey;
   [Write] string OctopusServerUrl;
   [Write] string Environments[];
   [Write] string Roles[];
-  [Write] UInt32 ListenPort;
-  [Write] string RegisteredNic;
   [Write] string DefaultApplicationDirectory;
 
-  [Write] boolean InitialDeploy;
-  [Write] string DeployProject[];
+  [Key] string DeployProject;
   [Write] string DeployVersion;
 };

--- a/DSCResources/cProjectDeploy/cProjectDeploy.schema.mof
+++ b/DSCResources/cProjectDeploy/cProjectDeploy.schema.mof
@@ -2,10 +2,8 @@
 class cProjectDeploy : OMI_BaseResource
 {
   [Write] string ApiKey;
-  [Write] string OctopusServerUrl;
+ [Write] string OctopusServerUrl;
   [Write] string Environments[];
-  [Write] string Roles[];
-  [Write] string DefaultApplicationDirectory;
 
   [Key] string DeployProject;
   [Write] string DeployVersion;

--- a/DSCResources/cProjectDeploy/cProjectDeploy.schema.mof
+++ b/DSCResources/cProjectDeploy/cProjectDeploy.schema.mof
@@ -1,0 +1,19 @@
+[ClassVersion("1.0.0"), FriendlyName("cTentacleAgent")] 
+class cTentacleAgent : OMI_BaseResource
+{
+  [Key] string Name;
+  [Write,ValueMap{"Present", "Absent"},Values{"Present", "Absent"}] string Ensure;
+  [Write,ValueMap{"Started","Stopped"},Values{"Started", "Stopped"}] string State;
+
+  [Write] string ApiKey;
+  [Write] string OctopusServerUrl;
+  [Write] string Environments[];
+  [Write] string Roles[];
+  [Write] UInt32 ListenPort;
+  [Write] string RegisteredNic;
+  [Write] string DefaultApplicationDirectory;
+
+  [Write] boolean InitialDeploy;
+  [Write] string DeployProject[];
+  [Write] string DeployVersion;
+};

--- a/DSCResources/cTentacleAgent/cTentacleAgent.psm1
+++ b/DSCResources/cTentacleAgent/cTentacleAgent.psm1
@@ -18,10 +18,10 @@ function Get-TargetResource
         [string[]]$Roles,
         [string]$DefaultApplicationDirectory,
         [int]$ListenPort,
-        [string]$RegisteredNic,
-        [bool]$InitialDeploy,
+        [string]$RegisteredNic
+        <#[bool]$InitialDeploy,
         [string[]]$DeployProject,
-        [string]$DeployVersion
+        [string]$DeployVersion#>
     )
 
     Write-Verbose "Checking if Tentacle is installed"
@@ -81,10 +81,10 @@ function Set-TargetResource
         [string[]]$Roles,
         [string]$DefaultApplicationDirectory = "$($env:SystemDrive)\Applications",
         [int]$ListenPort = 10933,
-        [string]$RegisteredNic,
-        [bool]$InitialDeploy = $false,
+        [string]$RegisteredNic
+        <#[bool]$InitialDeploy = $false,
         [string[]]$DeployProject,
-        [string]$DeployVersion
+        [string]$DeployVersion#>
    )
 
     if ($Ensure -eq "Absent" -and $State -eq "Started") 
@@ -147,7 +147,7 @@ function Set-TargetResource
         Write-Verbose "Starting $serviceName"
         Start-Service -Name $serviceName
     }
-    if ($State -eq "Started" -and $Ensure -eq "Present" -and $InitialDeploy)
+    <#if ($State -eq "Started" -and $Ensure -eq "Present" -and $InitialDeploy)
     {
         foreach($project in $DeployProject){
 			if ($DeployVersion -and $DeployProject.count -eq 1)
@@ -159,7 +159,7 @@ function Set-TargetResource
 				Invoke-InitialDeploy -name $Name -apiKey $ApiKey -octopusServerUrl $octopusServerUrl -Environments $Environments -Project $project -Wait
 			}
 		}
-    }
+    }#>
 
     Write-Verbose "Finished"
 }
@@ -183,10 +183,10 @@ function Test-TargetResource
         [string[]]$Roles,
         [string]$DefaultApplicationDirectory,
         [int]$ListenPort,
-        [string]$RegisteredNic,
-        [bool]$InitialDeploy,
+        [string]$RegisteredNic
+        <#[bool]$InitialDeploy,
         [string[]]$DeployProject,
-        [string]$DeployVersion
+        [string]$DeployVersion#>
     )
  
     $currentResource = (Get-TargetResource -Name $Name)
@@ -379,7 +379,7 @@ function Remove-TentacleRegistration
     }
 }
 
-function Invoke-InitialDeploy
+<#function Invoke-InitialDeploy
 {
     param (
         [Parameter(Mandatory=$True)]
@@ -427,5 +427,5 @@ function Invoke-InitialDeploy
         Invoke-AndAssert { & .\octo.exe $deployArguments}
     }
     "Done" | Out-File "$($env:SystemDrive)\Octopus\OctopusTools\$($Project)_initial.txt"
-}
+}#>
 

--- a/DSCResources/cTentacleAgent/cTentacleAgent.psm1
+++ b/DSCResources/cTentacleAgent/cTentacleAgent.psm1
@@ -247,6 +247,10 @@ function Get-MyPublicIPAddress([string]$RegisteredNic,[bool]$isNatted,[string]$O
     }
 
     #Test the connection to the Octopus Server. If it is not reachable, throw an error
+    $urlRegex = ‘([a-zA-Z]{3,})://([\w-]+\.)+[\w-]+(/[\w- ./?%&=]*)*?’
+    if($OctopusServerUrl -match $urlRegex){
+        $OctopusServerUrl = $OctopusServerUrl.Split("//") | select -Last 1
+    }
     $adapterTest = Test-NetConnection $OctopusServerUrl -Port $port
     if(!($adapterTest.TcpTestSucceeded -and ($adapterTest.InterfaceAlias -eq $RegisteredNic))){
         throw "Cannot reach Octopus Server $($OctopusServerUrl) from Network $($RegisteredNic). Please check your connection and try running your configuration again"

--- a/DSCResources/cTentacleAgent/cTentacleAgent.psm1
+++ b/DSCResources/cTentacleAgent/cTentacleAgent.psm1
@@ -18,10 +18,8 @@ function Get-TargetResource
         [string[]]$Roles,
         [string]$DefaultApplicationDirectory,
         [int]$ListenPort,
-        [string]$RegisteredNic
-        <#[bool]$InitialDeploy,
-        [string[]]$DeployProject,
-        [string]$DeployVersion#>
+        [string]$RegisteredNic,
+        [bool]$isNatted=$false
     )
 
     Write-Verbose "Checking if Tentacle is installed"
@@ -81,10 +79,8 @@ function Set-TargetResource
         [string[]]$Roles,
         [string]$DefaultApplicationDirectory = "$($env:SystemDrive)\Applications",
         [int]$ListenPort = 10933,
-        [string]$RegisteredNic
-        <#[bool]$InitialDeploy = $false,
-        [string[]]$DeployProject,
-        [string]$DeployVersion#>
+        [string]$RegisteredNic,
+        [bool]$isNatted=$false
    )
 
     if ($Ensure -eq "Absent" -and $State -eq "Started") 
@@ -137,7 +133,7 @@ function Set-TargetResource
     elseif ($Ensure -eq "Present" -and $currentResource["Ensure"] -eq "Absent") 
     {
         Write-Verbose "Installing Tentacle..."
-        New-Tentacle -name $Name -apiKey $ApiKey -octopusServerUrl $OctopusServerUrl -port $ListenPort -RegisteredNic $RegisteredNic -environments $Environments -roles $Roles -DefaultApplicationDirectory $DefaultApplicationDirectory
+        New-Tentacle -name $Name -apiKey $ApiKey -octopusServerUrl $OctopusServerUrl -port $ListenPort -RegisteredNic $RegisteredNic -isNatted $isNatted -environments $Environments -roles $Roles -DefaultApplicationDirectory $DefaultApplicationDirectory
         Write-Verbose "Tentacle installed!"
     }
 
@@ -147,19 +143,6 @@ function Set-TargetResource
         Write-Verbose "Starting $serviceName"
         Start-Service -Name $serviceName
     }
-    <#if ($State -eq "Started" -and $Ensure -eq "Present" -and $InitialDeploy)
-    {
-        foreach($project in $DeployProject){
-			if ($DeployVersion -and $DeployProject.count -eq 1)
-			{
-				Invoke-InitialDeploy -name $Name -apiKey $ApiKey -octopusServerUrl $octopusServerUrl -Environments $Environments -Project $project -Version $DeployVersion -Wait
-			}
-			else
-			{
-				Invoke-InitialDeploy -name $Name -apiKey $ApiKey -octopusServerUrl $octopusServerUrl -Environments $Environments -Project $project -Wait
-			}
-		}
-    }#>
 
     Write-Verbose "Finished"
 }
@@ -183,10 +166,8 @@ function Test-TargetResource
         [string[]]$Roles,
         [string]$DefaultApplicationDirectory,
         [int]$ListenPort,
-        [string]$RegisteredNic
-        <#[bool]$InitialDeploy,
-        [string[]]$DeployProject,
-        [string]$DeployVersion#>
+        [string]$RegisteredNic,
+        [bool]$isNatted=$false
     )
  
     $currentResource = (Get-TargetResource -Name $Name)
@@ -247,13 +228,30 @@ function Invoke-AndAssert {
 # After the Tentacle is registered with Octopus, Tentacle listens on a TCP port, and Octopus connects to it. The Octopus server
 # needs to know the public IP address to use to connect to this Tentacle instance. Is there a way in Windows Azure in which we can 
 # know the public IP/host name of the current machine?
-function Get-MyPublicIPAddress([string]$RegisteredNic)
-{
-    Write-Verbose "Getting IP address of $($RegisteredNic) NIC"
-    $ip = Get-NetIPAddress -InterfaceAlias $RegisteredNic -AddressFamily IPv4 | select -exp IPAddress
-    <#$downloader = new-object System.Net.WebClient
-    $ip = $downloader.DownloadString("http://icanhazip.com").Trim()#>
-    return $ip
+function Get-MyPublicIPAddress([string]$RegisteredNic,[bool]$isNatted,[string]$OctopusServerUrl,[int]$port){
+    #First Verify the adapter exists
+    $netAdapter = Get-NetAdapter -InterfaceAlias $RegisteredNic -ErrorAction SilentlyContinue
+    if($netAdapter -eq $null){
+        throw "Selected NIC $($RegisteredNic) does not exist"
+    }
+
+    #If adapter is natted, find the actual Public IP
+    if($isNatted){
+        Write-Verbose "NIC $($RegisteredNic) is natted. Determining actual public IP"
+        $downloader = new-object System.Net.WebClient
+        $ip = $downloader.DownloadString("http://icanhazip.com").Trim()
+    }
+    else{
+        Write-Verbose "Getting IP address of $($RegisteredNic) NIC"
+        $ip = Get-NetIPAddress -InterfaceAlias $RegisteredNic -AddressFamily IPv4 | select -exp IPAddress
+    }
+
+    #Test the connection to the Octopus Server. If it is not reachable, throw an error
+    $adapterTest = Test-NetConnection $OctopusServerUrl -Port $port
+    if(!($adapterTest.TcpTestSucceeded -and ($adapterTest.InterfaceAlias -eq $RegisteredNic))){
+        throw "Cannot reach Octopus Server $($OctopusServerUrl) from Network $($RegisteredNic). Please check your connection and try running your configuration again"
+    }
+    else{return $ip}
 }
  
 function New-Tentacle 
@@ -271,6 +269,7 @@ function New-Tentacle
         [string[]]$roles,
         [int] $port,
         [string]$RegisteredNic,
+        [bool]$isNatted=$false,
         [string]$DefaultApplicationDirectory
     )
  
@@ -308,8 +307,7 @@ function New-Tentacle
     Write-Verbose "Open port $port on Windows Firewall"
     Invoke-AndAssert { & netsh.exe advfirewall firewall add rule protocol=TCP dir=in localport=$port action=allow name="Octopus Tentacle: $Name" }
     
-    $ipAddress = Get-MyPublicIPAddress $RegisteredNic
-    #$ipAddress = $ipAddress.Trim()
+    $ipAddress = Get-MyPublicIPAddress -RegisteredNic $RegisteredNic -isNatted $isNatted -OctopusServerUrl $octopusServerUrl -port $port
  
     Write-Verbose "Public IP address: $ipAddress"
     Write-Verbose "Configuring and registering Tentacle"
@@ -378,54 +376,3 @@ function Remove-TentacleRegistration
         Write-Verbose "Could not find Tentacle.exe"
     }
 }
-
-<#function Invoke-InitialDeploy
-{
-    param (
-        [Parameter(Mandatory=$True)]
-        [string]$name,
-        [Parameter(Mandatory=$True)]
-        [string]$apiKey,
-        [Parameter(Mandatory=$True)]
-        [string]$octopusServerUrl,
-        [Parameter(Mandatory=$True)]
-        [string]$Project,
-        [Parameter(Mandatory=$True)]
-        [string[]]$Environments,
-        [string]$Version = "latest",
-        [Switch]$Wait = $true
-    )
-
-    $octoDL = "http://download.octopusdeploy.com/octopus-tools/2.5.10.39/OctopusTools.2.5.10.39.zip"
-    if (Test-Path "$($env:SystemDrive)\Octopus\OctopusTools\$($Project)_initial.txt")
-    {
-        Write-Verbose "Initial Deployment for $Project already done, nothing to do"
-        return
-    }
-
-    if ( -not (Test-Path "$($env:SystemDrive)\Octopus\OctopusTools\Octo.exe"))
-    {
-        if ( -not (Test-Path "$($env:SystemDrive)\Octopus\OctopusTools.zip"))
-        {
-            Write-Verbose "Downloading OctopusTools from $octoDL"
-            Request-File -url $octoDL -saveAs "$($env:SystemDrive)\Octopus\OctopusTools.zip"
-        }
-        Write-Verbose "Unpacking OctopusTools to $($env:SystemDrive)\Octopus\OctopusTools\"
-        Add-Type -assemblyname System.IO.Compression.FileSystem
-        [System.IO.Compression.ZipFile]::ExtractToDirectory("$($env:SystemDrive)\Octopus\OctopusTools.zip","$($env:SystemDrive)\Octopus\OctopusTools\")
-
-    }
-    pushd "$($env:SystemDrive)\Octopus\OctopusTools\"
-    foreach ($environment in $environments)
-    {
-        Write-Verbose "Deploying Project $Project to environment $environment"
-        $deployArguments = @("deploy-release", "--project", $Project, "--deployto", $environment, "--releaseNumber", $Version, "--specificmachines", $env:COMPUTERNAME, "--server", $octopusServerUrl, "--apiKey", $apiKey)
-        if ($Wait)
-        {
-            $deployArguments += "--waitfordeployment"
-        }
-        Invoke-AndAssert { & .\octo.exe $deployArguments}
-    }
-    "Done" | Out-File "$($env:SystemDrive)\Octopus\OctopusTools\$($Project)_initial.txt"
-}#>
-

--- a/DSCResources/cTentacleAgent/cTentacleAgent.schema.mof
+++ b/DSCResources/cTentacleAgent/cTentacleAgent.schema.mof
@@ -11,5 +11,6 @@ class cTentacleAgent : OMI_BaseResource
   [Write] string Roles[];
   [Write] UInt32 ListenPort;
   [Write] string RegisteredNic;
+  [Write] boolean isNatted;
   [Write] string DefaultApplicationDirectory;
 };

--- a/DSCResources/cTentacleAgent/cTentacleAgent.schema.mof
+++ b/DSCResources/cTentacleAgent/cTentacleAgent.schema.mof
@@ -10,6 +10,7 @@ class cTentacleAgent : OMI_BaseResource
   [Write] string Environments[];
   [Write] string Roles[];
   [Write] UInt32 ListenPort;
+  [Write] string RegisteredNic;
   [Write] string DefaultApplicationDirectory;
 
   [Write] boolean InitialDeploy;

--- a/DSCResources/cTentacleAgent/cTentacleAgent.schema.mof
+++ b/DSCResources/cTentacleAgent/cTentacleAgent.schema.mof
@@ -12,8 +12,4 @@ class cTentacleAgent : OMI_BaseResource
   [Write] UInt32 ListenPort;
   [Write] string RegisteredNic;
   [Write] string DefaultApplicationDirectory;
-
-  [Write] boolean InitialDeploy;
-  [Write] string DeployProject[];
-  [Write] string DeployVersion;
 };

--- a/README.md
+++ b/README.md
@@ -13,24 +13,25 @@ Configuration SampleConfig
  
     Node "localhost"
     {
-        cTentacleAgent OctopusTentacle 
-        { 
-            Ensure = "Present"; 
-            State = "Started"; 
- 
+        cTentacleAgent OctopusTentacle{ 
+            Ensure = "Present" 
+            State = "Started"
+
             # Tentacle instance name. Leave it as 'Tentacle' unless you have more 
             # than one instance
-            Name = "Tentacle";
- 
+            Name = "Tentacle"
+
             # Registration - all parameters required
-            ApiKey = $ApiKey;
-            OctopusServerUrl = $OctopusServerUrl;
-            Environments = $Environments;
-            Roles = $Roles;
- 
+            ApiKey = "API-ABCDEF12345678910"
+            OctopusServerUrl = "https://demo.octopusdeploy.com/"
+            Environments = "Staging"
+            Roles = @("web-server", "app-server")
+
             # Optional settings
-            ListenPort = $ListenPort;
-            DefaultApplicationDirectory = "C:\Applications"
+            ListenPort = 10933
+            RegisteredNic = "Public"
+            isNatted = $false
+            DefaultApplicationDirectory = "C:\Octopus"
         }
     }
 }
@@ -52,14 +53,13 @@ Configuration SampleConfig
  
     Node "localhost"
 	{
-		cProjectDeploy SampleProject
-		{
-			ApiKey = $ApiKey
-			OctopusServerUrl = $OctopusServerUrl
-			DeployProject = $DeployProject
-			Environments = $Environments
-			DeployVersion = $DeployVersion
-		}
+		cProjectDeploy Config{
+            ApiKey = "API-ABCDEF12345678910"
+            OctopusServerUrl = "https://demo.octopusdeploy.com/"
+            DeployProject = "Sample Project"
+            Environments = "Staging"
+            DeployVersion = "1.1.0.121"
+        }
 	}
 }
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,36 @@ Start-DscConfiguration .\SampleConfig -Verbose -wait
 Test-DscConfiguration
 ```
 
+## Deploying Projects
+```
+Configuration SampleConfig
+{
+    param ($ApiKey, $OctopusServerUrl, $DeployProject, $DeployVersion, $Environments, $Roles, $ListenPort)
+ 
+    Import-DscResource -Module OctopusDSC
+ 
+    Node "localhost"
+	{
+		cProjectDeploy SampleProject
+		{
+			ApiKey = $ApiKey
+			OctopusServerUrl = $OctopusServerUrl
+			DeployProject = $DeployProject
+			Environments = $Environments
+			DeployVersion = $DeployVersion
+		}
+	}
+}
+
+SampleConfig -ApiKey "API-ABCDEF12345678910" -OctopusServerUrl "https://demo.octopusdeploy.com/" -DeployProject "DotNet Project" -DeployVersion "1.0.3" -Environments @("Development") -Roles @("web-server", "app-server") -ListenPort 10933
+
+Start-DscConfiguration .\SampleConfig -Verbose -wait
+
+Test-DscConfiguration
+```
+
+Repeat this config block as many times as necessary to deploy all projects.
+
 ## Settings
 
 When `Ensure` is set to `Present`, the resource will:


### PR DESCRIPTION
Completed the following Updates:
- Revamped tentacle registration so you can select which NIC to bind to. Useful for customer who want to pin OctopusDeploy traffic to a private network.
- Pulled project deployment into it's own resource. Useful for customers who want to deploy multiple projects at specific version numbers.
